### PR TITLE
This change allows for the user to input include and exclude list fil…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 
 #Dot file
 graph.dot
+completegraph.dot
 
 # Runtime data
 pids

--- a/messages/depends.json
+++ b/messages/depends.json
@@ -3,5 +3,9 @@
   "resultformatFlagDescription": "the result format of the graph output; ignore with --json",
   "metadatacomponentnameFlagDescription": "filter by component in the format '<entityType>.<entityName>; e.g. CustomField.Thumbnail",
   "querycriteriaFlagDescription": "the criteria to filter the dependency records; e.g. RefMetadataComponentName='Thumbnail'",
+  "includeListDescription": "the list of fields to include when querying. Separate fields by commas. Adding a colon allows you to specify the name of specific custom object to include e.g 'CustomField:Thumbnail, CustomObject'",
+  "excludeListDescription": "list of fields to exclude when querying. Adding a colon allows you to specify the name of specific custom object to exclude e.g 'CustomField:Thumbnail, CustomObject'",
+  "generatePackageDescription": "Whether or not you want to generate a package, the input is the output folder",
+  "getIncludeDependencies": "For all objects in the include list, get all dependencies, including dependencies for dependencies",
   "example1": "$ sfdx andyinthelcloud:depends --metadatacomponentname CustomField.Thumbnail"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "dependencies": {
     "@oclif/config": "^1.6.27",
     "@oclif/errors": "^1.0.9",
-    "@salesforce/command": "0.1.5"
+    "@salesforce/command": "0.1.5",
+    "debug": "^3.1.0",
+    "file-system": "^2.2.2"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.2.20",

--- a/src/commands/andyinthecloud/dependencies/componentizer.ts
+++ b/src/commands/andyinthecloud/dependencies/componentizer.ts
@@ -1,12 +1,17 @@
 // import {flags} from '@oclif/command';
-import {join} from 'path';
-import {core, SfdxCommand} from '@salesforce/command';
 import assert = require('assert');
+import {join} from 'path';
+import {ClusterPackager } from '../../../lib/clusterPackager';
+import {FindCycles} from '../../../lib/DFSLib';
+import {core, SfdxCommand} from '@salesforce/command';
+import {Graph, Node, NodeGroup, ScalarNode} from '../../../lib/componentGraph';
 
 core.Messages.importMessagesDirectory(join(__dirname, '..', '..', '..'));
 const messages = core.Messages.loadMessages('dependencies-cli', 'analyze');
 
 export default class Analyze extends SfdxCommand {
+    public static outputFolder = 'lib/';
+
     public static description = messages.getMessage('commandDescription');
 
     public static examples = [
@@ -24,6 +29,9 @@ export default class Analyze extends SfdxCommand {
     public static buildGraph(results: any): Graph {
         const graph: Graph = new Graph();
         for (const edge of results) {
+            if (edge.RefMetadataComponentName.startsWith('0')) {
+                continue;
+              }
             const srcId: string = edge.MetadataComponentId;
             const srcName = Analyze.makeName(edge.MetadataComponentNamespace, edge.MetadataComponentName);
             const srcType = edge.MetadataComponentType;
@@ -40,13 +48,13 @@ export default class Analyze extends SfdxCommand {
             }
 
             const srcDetails = new Map<string, object>();
-            srcDetails.set('name', new String(srcName));
-            srcDetails.set('type', new String(srcType));
+            srcDetails.set('name', (srcName as String));
+            srcDetails.set('type', (srcType as String));
             const srcNode: Node = graph.getOrAddNode(srcId, srcDetails);
 
             const dstDetails = new Map<string, object>();
-            dstDetails.set('name', new String(dstName));
-            dstDetails.set('type', new String(dstType));
+            dstDetails.set('name', (dstName as String));
+            dstDetails.set('type', (dstType as String));
             const dstNode: Node = graph.getOrAddNode(dstId, dstDetails);
             graph.addEdge(srcNode, dstNode);
         }
@@ -101,13 +109,13 @@ export default class Analyze extends SfdxCommand {
             return node.details.get('name') + '(' + node.name + ')';
         } else {
             const ng: NodeGroup = node as NodeGroup;
-            return Array.from(ng.nodes).map((n) => { return Analyze.nodeToDisplayName(n); }).join(', ');
+            return Array.from(ng.nodes).map(n => Analyze.nodeToDisplayName(n)).join(', ');
         }
     }
 
-    public async run(): Promise<any> {
+    public async run(): Promise<Map<string, Node[]>> {
         // const orgId = this.org.getOrgId();
-
+        const xmlWriter = new ClusterPackager(Analyze.outputFolder);
         const anyConn = this.org.getConnection();
         anyConn.version = '43.0';
         const conn = anyConn.tooling;
@@ -125,10 +133,11 @@ export default class Analyze extends SfdxCommand {
         for (const node of g.nodes) {
             const edges: Set<Node> = new Set<Node>(g.getEdges(node));
             // no outgoing edges or only self edges
-            if (edges.size == 0 || (edges.has(node) && edges.size == 1)) {
+            if (edges.size === 0 || (edges.has(node) && edges.size === 1)) {
                 let type: string;
                 if (node instanceof NodeGroup) {
                     type = 'Cluster';
+                    xmlWriter.writeXML((node as NodeGroup));
                 } else {
                     type = ((node.details.get('type')) as String).valueOf();
                 }
@@ -144,301 +153,18 @@ export default class Analyze extends SfdxCommand {
 
         if (leafNodes.size > 0) {
             this.ux.log('Leaf components by type');
-            Array.from(leafNodes.entries()).forEach((pair) => {
+            Array.from(leafNodes.entries()).forEach(pair => {
                 const type: string = pair[0];
                 const components: Node[] = pair[1];
                 this.ux.log(type + ':');
-                components.forEach((component) => {
+                components.forEach(component => {
                     const name = Analyze.nodeToDisplayName(component);
                     this.ux.log('\t' + name);
                 });
                 this.ux.log();
             });
         }
+        return leafNodes;
     }
-}
-
-export class Graph {
-    private _nodes: Map<string, Node> = new Map<string, Node>();
-    private _groupMap: Map<ScalarNode, NodeGroup> = new Map<ScalarNode, NodeGroup>();
-
-    public get nodes(): IterableIterator<Node> {
-        return this._nodes.values();
-    }
-
-    public getEdges(node: Node): IterableIterator<Node> {
-        const edges: Set<Node> = new Set<Node>();
-        (node as NodeImpl).getAdjacency().forEach((elt) => {
-            let mapped: Node;
-            if (elt instanceof ScalarNode) {
-                mapped = this._groupMap.get(elt);
-            }
-            edges.add(mapped ? mapped : elt);
-        });
-
-        if (node instanceof ScalarNode) {
-            edges.delete(this._groupMap.get(node));
-        }
-        return edges.values();
-    }
-
-    public addEdge(src: Node, dst: Node): void {
-       (src as NodeImpl).addEdge(dst);
-    }
-    public getNode(name: string): Node {
-        return this._nodes.get(name);
-    }
-
-    public combineNodes(node1: Node, node2: Node): Node {
-        assert.ok(this._nodes.has(node1.name), node1.name + ' doesn\'t exist');
-        assert.ok(this._nodes.has(node2.name), node2.name + ' doesn\'t exist');
-        if (node1 === node2) {
-            // already the same node, so nothing to do.
-            return;
-        }
-        // combining nodes changes the name of the node, so we have to remove node1 and node2 from the
-        // _nodes map first, then put the maybe new node back.
-        this._nodes.delete(node1.name);
-        this._nodes.delete(node2.name);
-        const ng: NodeGroup = (node1 as NodeImpl).combineWith(node2 as NodeImpl);
-        if (node1 instanceof ScalarNode) {
-            this._groupMap.set(node1, ng);
-        }
-        if (node2 instanceof ScalarNode) {
-            this._groupMap.set(node2, ng);
-        }
-        this._nodes.set(ng.name, ng);
-        return ng;
-    }
-
-    public getOrAddNode(name: string, details: Map<string, object>): Node {
-        let n: Node = this._nodes.get(name);
-        if (n) {
-            return n;
-        }
-
-        n = new ScalarNode(name, details);
-        this._nodes.set(name, n);
-        return n;
-    }
-
-}
-
-export interface Node {
-    readonly name: string;
-    details: Map<string, object>;
-}
-
-abstract class NodeImpl implements Node {
-    private readonly _name: string;
-    private readonly _details: Map<string, object>;
-
-    public get name(): string {
-        return this._name;
-    }
-
-    public get details(): Map<string, object> {
-        return this._details;
-    }
-
-    constructor(name: string, details: Map<string, object>) {
-        this._name = name;
-        this._details = details;
-    }
-    public abstract getAdjacency(): Map<string, Node>;
-    public abstract addEdge(dest: Node): void;
-    public abstract combineWith(rhs: NodeImpl): NodeGroup;
-}
-
-class ScalarNode extends NodeImpl {
-    private edges: Map<string, Node> = new Map<string, Node>();
-
-    constructor(name: string, details: Map<string, object>) {
-        super(name, details);
-    }
-
-    public addEdge(dest: Node) {
-        if (!this.edges.has(dest.name)) {
-            this.edges.set(dest.name, dest);
-        }
-    }
-
-    public getAdjacency(): Map<string, Node> {
-        return this.edges;
-    }
-
-    public combineWith(rhs: NodeImpl): NodeGroup {
-        if (rhs instanceof NodeGroup) {
-            return rhs.combineWith(this);
-        }
-
-        const ng: NodeGroup = new NodeGroup();
-        ng.addNode(this);
-        ng.addNode(rhs);
-        return ng;
-    }
-}
-
-class NodeGroup extends NodeImpl {
-    private readonly _nodes: Set<ScalarNode> = new Set<ScalarNode>();
-    private adjacencyCache: Map<string, ScalarNode>;
-
-    constructor() {
-        super('NodeGroup', undefined);
-    }
-
-    public get name(): string {
-        return Array.from(this.nodes).map((node) => node.name).sort().join(', ');
-    }
-
-    get nodes(): Set<ScalarNode> {
-        return this._nodes;
-    }
-
-    public get details(): Map<string, object> {
-        const ret: Map<string, object> = new Map<string, object>();
-        this.nodes.forEach((element) => {
-            Array.from(element.details.entries()).forEach((detail) => {
-               ret.set(detail[0], detail[1]);
-            });
-        });
-        return ret;
-    }
-
-    public addEdge(dest: Node) {
-        throw new Error('Don\'t add edges to combined nodes');
-    }
-
-    public getAdjacency(): Map<string, Node> {
-        if (this.adjacencyCache) {
-            return this.adjacencyCache as Map<string, Node>;
-        }
-
-        this.adjacencyCache = new Map<string, ScalarNode>();
-        this.nodes.forEach((element) => {
-            element.getAdjacency().forEach((n) => {
-                    // if a node has a cycle to itself then preserve it.  if it's an
-                    // edge between two nodes in the nodegroup, skip it.
-                    if (element === n || !this.nodes.has(n as ScalarNode)) {
-                        this.adjacencyCache.set(n.name, n as ScalarNode);
-                    }
-                }
-            );
-        });
-        return this.adjacencyCache;
-    }
-    public combineWith(rhs: NodeImpl): NodeGroup {
-        if (rhs instanceof ScalarNode) {
-            this.addNode(rhs);
-            this.adjacencyCache = null;
-            return this;
-        }
-
-        assert.ok(rhs instanceof NodeGroup);
-        (rhs as NodeGroup).nodes.forEach((element) => {
-                this.nodes.add(element);
-            }
-        );
-
-        return rhs as NodeGroup;
-    }
-
-    public addNode(node: NodeImpl): void {
-        assert.ok(node as ScalarNode);
-        this.nodes.add(node as ScalarNode);
-    }
-}
-
-export abstract class DepthFirstSearch {
-    private readonly graph: Graph;
-    private readonly state: Set<Node>;
-    constructor(g: Graph) {
-        this.graph = g;
-        this.state = new Set<Node>();
-    }
-
-    public run() {
-        for (const node of this.graph.nodes) {
-            if (this.state.has(node)) {
-                // this node was processed by a previous call to dfs
-                return;
-            }
-
-            this.dfs(node);
-        }
-    }
-
-    public abstract visit(node: Node);
-    public abstract explore(src: Node, dst: Node);
-    public abstract finish(node: Node);
-
-    private dfs(node: Node) {
-        this.visit(node);
-
-        for (const dst of this.graph.getEdges(node)) {
-            this.explore(node, dst);
-            if (this.state.has(dst)) {
-                // already visited this node
-                continue;
-            }
-            this.state.add(dst);
-            this.dfs(dst);
-        }
-
-        this.finish(node);
-    }
-}
-export class FindCycles extends DepthFirstSearch {
-    public visited: Set<Node> = new Set<Node>();
-    public finished: Set<Node> = new Set<Node>();
-    public cycles: Node[][] = new Array<Node[]>();
-
-    public visit(node: Node) {
-        this.visited.add(node);
-    }
-    public finish(node: Node) {
-        this.finished.add(node);
-    }
-    public explore(src: Node, dst: Node) {
-        // ignore self cycles
-        if (src === dst) {
-            return;
-        }
-
-        // if we have an edge to a node that is visited but not finished, then it's
-        // a back edge
-        if (this.visited.has(dst) && !this.finished.has(dst)) {
-                // This is a cycle
-                this.cycles.push([src, dst]);
-        }
-    }
-
-/*
-export class FindCycles extends DepthFirstSearch {
-    public indices: Map<Node, number> = new Map<Node, number>();
-    public cycles: Node[][] = new Array<Node[]>();
-
-    public visit(node: Node) {
-        // record the visit order for nodes
-        if (!this.indices.has(node)) {
-           this.indices.set(node, this.indices.size);
-        }
-    }
-
-    public explore(src: Node, dst: Node) {
-        const srcIdx = this.indices.get(src);
-        const dstIdx = this.indices.get(dst);
-        if (dstIdx !== null) {
-            // allow self cycles, so only check for greater.
-            if (srcIdx > dstIdx) {
-                console.log('Back edge: ' + src.name + '(' + srcIdx + ') => ' + dst.name + '(' + dstIdx + ')');
-                // This is a cycle
-                this.cycles.push([src, dst]);
-            }
-        }
-    }
-    public finish(node: Node) {
-    }
-    */
 
 }

--- a/src/commands/andyinthecloud/dependencies/report.ts
+++ b/src/commands/andyinthecloud/dependencies/report.ts
@@ -1,8 +1,10 @@
-import { core, flags, SfdxCommand } from '@salesforce/command';
+import * as Analyze from '../dependencies/componentizer';
+import {core, flags, SfdxCommand } from '@salesforce/command';
+import {ClusterPackager} from '../../../lib/clusterPackager';
 import { DependencyGraph, MetadataComponentDependency } from '../../../lib/dependencyGraph';
+import {FindAllDependencies} from '../../../lib/DFSLib';
 
 core.Messages.importMessagesDirectory(__dirname);
-
 const messages = core.Messages.loadMessages('dependencies-cli', 'depends');
 
 export default class Org extends SfdxCommand {
@@ -11,8 +13,16 @@ export default class Org extends SfdxCommand {
 
   protected static flagsConfig = {
     resultformat: flags.string({ char: 'r', description: messages.getMessage('resultformatFlagDescription'), default: 'dot', options: ['dot'] }),
-    metadatacomponentname: flags.string({ char: 'm', description: messages.getMessage('metadatacomponentnameFlagDescription') }),
-    querycriteria: flags.string({ char: 'q', description: messages.getMessage('querycriteriaFlagDescription') })
+    // metadatacomponentname: flags.string({ char: 'm', description: messages.getMessage('metadatacomponentnameFlagDescription') }),
+    // querycriteria: flags.string({ char: 'q', description: messages.getMessage('querycriteriaFlagDescription') }),
+    includelist: flags.string({char: 'i', description: messages.getMessage('includeListDescription')}),
+    excludelist: flags.string({char: 'e', description: messages.getMessage('excludeListDescription')}),
+    generatepackage: flags.string({char: 'o', description: messages.getMessage('generatePackageDescription')}),
+    getincludedependencies: flags.boolean({
+      char: 't',
+      description: messages.getMessage('getIncludeDependencies'),
+      dependsOn: ['includelist']
+    })
   };
 
   protected static requiresUsername = true;
@@ -22,8 +32,32 @@ export default class Org extends SfdxCommand {
     conn.version = '43.0';
 
     const deps = new DependencyGraph(conn.tooling);
-    await deps.init(await this.getDependencyRecords());
+    const records = await this.getDependencyRecords();
+    const initialGraph = Analyze.default.buildGraph(records);
 
+    let nodes = Array.from(initialGraph.nodes);
+
+    if (this.flags.getincludedependencies) {
+       const allRecords = await this.getAllRecords();
+       const completeGraph = Analyze.default.buildGraph(allRecords);
+       const dfs = new FindAllDependencies(completeGraph);
+       const initialNodes = Array.from(initialGraph.nodes);
+       initialNodes.forEach(element => {
+          dfs.runNode(completeGraph.getNode(element.name));
+       });
+       // Get all Nodes, including dependencies
+       nodes = Array.from(dfs.visited);
+       // Initialize the dependency graph with a filtered list of all Records
+       await deps.initWithFilter(allRecords, dfs.visitedNames);
+    } else {
+      // Initialize with the records from query
+      await deps.init(records);
+    }
+
+    if (this.flags.generatepackage) {
+      const cp = new ClusterPackager(this.flags.generatepackage);
+      cp.writeXMLNodes(nodes);
+    }
     // Only dot format is allowed by the flags property, but put
     // this check in case you add more later
     if (this.flags.resultformat === 'dot') {
@@ -35,19 +69,69 @@ export default class Org extends SfdxCommand {
   }
 
   private async getDependencyRecords() {
-    const query = this.org.getConnection().tooling.query<MetadataComponentDependency>('SELECT MetadataComponentId, MetadataComponentName, MetadataComponentType, RefMetadataComponentId, RefMetadataComponentName, RefMetadataComponentType FROM MetadataComponentDependency');
+    let queryString = 'SELECT MetadataComponentId, MetadataComponentName, MetadataComponentType, RefMetadataComponentId, RefMetadataComponentName, RefMetadataComponentType FROM MetadataComponentDependency';
+    let where = ' WHERE';
 
-    if (this.flags.querycriteria) {
-      query.where(this.flags.querycriteria);
+    if (this.flags.includelist) {
+      const list = this.flags.includelist;
+      const listArray = list.split(',');
+      let total = '';
+      listArray.forEach(element => {
+        const filterArr = element.split(':');
+        const filtertype = filterArr[0];
+        let addition: string;
+        if (filterArr.length > 1) {
+          const filtername = filterArr[1];
+          addition = `((RefMetadataComponentName = '${filtername}' AND RefMetadataComponentType = '${filtertype}') OR (MetadataComponentName = '${filtername}' AND MetadataComponentType = '${filtertype}'))`;
+        } else {
+          addition = `(RefMetadataComponentType = '${filtertype}' OR MetadataComponentType = '${filtertype}')`;
+        }
+        if (total !== '') {
+          total = total.concat(` OR (${addition})`);
+        } else {
+          total = `(${addition})`;
+        }
+      });
+      where = where.concat(` (${total})`);
     }
 
-    if (this.flags.metadatacomponentname) {
-      const filter = this.flags.metadatacomponentname;
-      const filtername = filter != null ? filter.split('.')[1] : null;
-      const filtertype = filter != null ? filter.split('.')[0] : null;
-      query.where(`RefMetadataComponentName = '${filtername}' AND RefMetadataComponentType = '${filtertype}' AND (NOT MetadataComponentName LIKE '%Test')`);
+    if (this.flags.excludelist) {
+      const list = this.flags.excludelist;
+      const listArray = list.split(',');
+      let total = '';
+      listArray.forEach(element => {
+        const filterArr = element.split(':');
+        const filtertype = filterArr[0];
+        let addition: string;
+        if (filterArr.length > 1) {
+          const filtername = filterArr[1];
+          addition = `((RefMetadataComponentName = '${filtername}' AND RefMetadataComponentType = '${filtertype}') OR (MetadataComponentName = '${filtername}' AND MetadataComponentType = '${filtertype}'))`;
+        } else {
+          addition = `(RefMetadataComponentType = '${filtertype}' OR MetadataComponentType = '${filtertype}')`;
+        }
+        if (total !== '') {
+          total = total.concat(` OR (${addition})`);
+        } else {
+          total = `(${addition})`;
+        }
+      });
+      if (where !== ' WHERE') {
+         where = where.concat(' AND');
+      }
+      where = where.concat(` (NOT (${total}))`);
     }
 
+    if (where !== ' WHERE') {
+      queryString = queryString.concat(where);
+    }
+    const query = this.org.getConnection().tooling.query<MetadataComponentDependency>(queryString);
     return (await query).records;
   }
+
+  private async getAllRecords() {
+    const queryString = 'SELECT MetadataComponentId, MetadataComponentName, MetadataComponentType, RefMetadataComponentId, RefMetadataComponentName, RefMetadataComponentType FROM MetadataComponentDependency';
+    const query = this.org.getConnection().tooling.query<MetadataComponentDependency>(queryString);
+    return (await query).records;
+  }
+
 }

--- a/src/lib/DFSLib.ts
+++ b/src/lib/DFSLib.ts
@@ -1,0 +1,91 @@
+import {Graph, Node} from '../lib/componentGraph';
+
+export abstract class DepthFirstSearch {
+    protected readonly graph: Graph;
+    private readonly state: Set<Node>;
+    constructor(g: Graph) {
+        this.graph = g;
+        this.state = new Set<Node>();
+    }
+
+    public run() {
+        for (const node of this.graph.nodes) {
+            if (this.state.has(node)) {
+                // this node was processed by a previous call to dfs
+                return;
+            }
+
+            this.dfs(node);
+        }
+    }
+
+    public abstract visit(node: Node);
+    public abstract explore(src: Node, dst: Node);
+    public abstract finish(node: Node);
+
+    protected dfs(node: Node) {
+        this.visit(node);
+
+        for (const dst of this.graph.getEdges(node)) {
+            this.explore(node, dst);
+            if (this.state.has(dst)) {
+                // already visited this node
+                continue;
+            }
+            this.state.add(dst);
+            this.dfs(dst);
+        }
+
+        this.finish(node);
+    }
+}
+
+export class FindAllDependencies extends DepthFirstSearch {
+    public visited: Set<Node> = new Set<Node>();
+    public finished: Set<Node> = new Set<Node>();
+    public visitedNames: Set<String> = new Set<String>();
+
+    public visit(node: Node) {
+        this.visited.add(node);
+        this.visitedNames.add(node.name);
+    }
+    public finish(node: Node) {
+        this.finished.add(node);
+    }
+
+    public runNode(node: Node) {
+        if (!this.visited.has(node)) {
+            this.dfs(node);
+        }
+    }
+
+    public explore(src: Node, dst: Node) {
+    }
+}
+
+export class FindCycles extends DepthFirstSearch {
+    public visited: Set<Node> = new Set<Node>();
+    public finished: Set<Node> = new Set<Node>();
+    public cycles: Node[][] = new Array<Node[]>();
+
+    public visit(node: Node) {
+        this.visited.add(node);
+    }
+    public finish(node: Node) {
+        this.finished.add(node);
+    }
+    public explore(src: Node, dst: Node) {
+        // ignore self cycles
+        if (src === dst) {
+            return;
+        }
+
+        // if we have an edge to a node that is visited but not finished, then it's
+        // a back edge
+        if (this.visited.has(dst) && !this.finished.has(dst)) {
+                // This is a cycle
+                this.cycles.push([src, dst]);
+        }
+    }
+
+}

--- a/src/lib/clusterPackager.ts
+++ b/src/lib/clusterPackager.ts
@@ -1,0 +1,118 @@
+import fs = require('fs');
+import {Node, NodeGroup} from '../lib/componentGraph';
+
+export class ClusterPackager {
+
+    constructor(private outputFolder: string) { }
+
+    public writeXMLNodes(n: Node[]) {
+        // Make output folder
+        const dir = this.outputFolder + '/';
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir);
+        }
+
+        const dest = dir + 'package.xml';
+        let text = this.writeHeader();
+
+        const typeMap = this.separateIntoGroupsFromNodes(n);
+        Array.from(typeMap.entries()).forEach(pair => {
+            text = text.concat((this.writeType(pair[0], pair[1]) as String).valueOf());
+        });
+
+        text = text.concat(this.writeFooter());
+
+        fs.writeFile(dest, text, err => {
+            // throws an error, you could also catch it here
+            if (err) {
+                throw err;
+            }
+        });
+
+    }
+
+    public writeXML(n: NodeGroup) {
+        // Make output folder
+        const dir = this.outputFolder + n.name + '/';
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir);
+        }
+        const dest = dir + 'package.xml';
+        let text = this.writeHeader();
+
+        const typeMap = this.separateIntoGroups(n);
+        Array.from(typeMap.entries()).forEach(pair => {
+            text = text.concat((this.writeType(pair[0], pair[1]) as String).valueOf());
+        });
+
+        text = text.concat(this.writeFooter());
+
+        fs.writeFile(dest, text, err => {
+            // throws an error, you could also catch it here
+            if (err) {
+                throw err;
+            }
+        });
+
+    }
+
+    private separateIntoGroups(n: NodeGroup): Map<String, String[]> {
+        const nodes = n.nodes;
+        return this.separateIntoGroupsFromNodes(Array.from(nodes));
+    }
+
+    // precondition: All nodes are Scalar Nodes
+    private separateIntoGroupsFromNodes(nodes: Node[]): Map<String, String[]> {
+        const output: Map<String, String[]>  = new Map<String, String[]>();
+        nodes.forEach(node => {
+            const type = ((node.details.get('type')) as String).valueOf();
+            let list = output.get(type);
+            if (!list) {
+                list = new Array<String>();
+                list.push(node.details.get('name') as String);
+                output.set(type, list);
+            } else {
+                list.push(node.details.get('name') as String);
+            }
+        });
+        return output;
+    }
+
+    private writeHeader(): string {
+        let header = '';
+        // Add XML version and encoding
+        header = header.concat('<?xml version=\"1.0\" encoding=\"UTF-8\"?>');
+        header = header.concat('\n');
+        header = header.concat('<Package xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n');
+        return header;
+    }
+
+    private writeType(type: String, nodes: String[]): String {
+        let typeBody = '\t<types>\n';
+        let ending = '';
+        if (type.startsWith('Custom')) {
+            ending = '__c';
+        }
+        for (const n of nodes) {
+            typeBody = typeBody.concat('\t\t<members>');
+            typeBody = typeBody.concat((n as String).valueOf());
+            typeBody = typeBody.concat(ending);
+            typeBody = typeBody.concat('</members>');
+            typeBody = typeBody.concat('\n');
+        }
+        typeBody = typeBody.concat('\t\t<name>');
+        typeBody = typeBody.concat(((type as String).valueOf()));
+        typeBody = typeBody.concat('</name>\n');
+        typeBody = typeBody.concat('\t</types>\n');
+        return typeBody;
+    }
+
+    private writeFooter(): string {
+        let footer = '';
+        // Set version to 34.0, may be a flag that can be added later
+        footer = footer.concat('\t<version>43.0</version>');
+        footer = footer.concat('\n');
+        footer = footer.concat('</Package>');
+        return footer;
+    }
+}

--- a/src/lib/componentGraph.ts
+++ b/src/lib/componentGraph.ts
@@ -1,0 +1,193 @@
+// TODO: Merge dependencyGraph and componentGraph
+import assert = require('assert');
+
+export class Graph {
+    private _nodes: Map<string, Node> = new Map<string, Node>();
+    private _groupMap: Map<ScalarNode, NodeGroup> = new Map<ScalarNode, NodeGroup>();
+
+    public get nodes(): IterableIterator<Node> {
+        return this._nodes.values();
+    }
+
+    public getEdges(node: Node): IterableIterator<Node> {
+        const edges: Set<Node> = new Set<Node>();
+        (node as NodeImpl).getAdjacency().forEach(elt => {
+            let mapped: Node;
+            if (elt instanceof ScalarNode) {
+                mapped = this._groupMap.get(elt);
+            }
+            edges.add(mapped ? mapped : elt);
+        });
+
+        if (node instanceof ScalarNode) {
+            edges.delete(this._groupMap.get(node));
+        }
+        return edges.values();
+    }
+
+    public addEdge(src: Node, dst: Node): void {
+       (src as NodeImpl).addEdge(dst);
+    }
+    public getNode(name: string): Node {
+        return this._nodes.get(name);
+    }
+
+    public combineNodes(node1: Node, node2: Node): Node {
+        assert.ok(this._nodes.has(node1.name), node1.name + ' doesn\'t exist');
+        assert.ok(this._nodes.has(node2.name), node2.name + ' doesn\'t exist');
+        if (node1 === node2) {
+            // already the same node, so nothing to do.
+            return;
+        }
+        // combining nodes changes the name of the node, so we have to remove node1 and node2 from the
+        // _nodes map first, then put the maybe new node back.
+        this._nodes.delete(node1.name);
+        this._nodes.delete(node2.name);
+        const ng: NodeGroup = (node1 as NodeImpl).combineWith(node2 as NodeImpl);
+        if (node1 instanceof ScalarNode) {
+            this._groupMap.set(node1, ng);
+        }
+        if (node2 instanceof ScalarNode) {
+            this._groupMap.set(node2, ng);
+        }
+        this._nodes.set(ng.name, ng);
+        return ng;
+    }
+
+    public getOrAddNode(name: string, details: Map<string, object>): Node {
+        let n: Node = this._nodes.get(name);
+        if (n) {
+            return n;
+        }
+
+        n = new ScalarNode(name, details);
+        this._nodes.set(name, n);
+        return n;
+    }
+
+}
+
+export interface Node {
+    readonly name: string;
+    details: Map<string, object>;
+}
+
+abstract class NodeImpl implements Node {
+    private readonly _name: string;
+    private readonly _details: Map<string, object>;
+
+    public get name(): string {
+        return this._name;
+    }
+
+    public get details(): Map<string, object> {
+        return this._details;
+    }
+
+    constructor(name: string, details: Map<string, object>) {
+        this._name = name;
+        this._details = details;
+    }
+    public abstract getAdjacency(): Map<string, Node>;
+    public abstract addEdge(dest: Node): void;
+    public abstract combineWith(rhs: NodeImpl): NodeGroup;
+}
+
+export class ScalarNode extends NodeImpl {
+    private edges: Map<string, Node> = new Map<string, Node>();
+
+    constructor(name: string, details: Map<string, object>) {
+        super(name, details);
+    }
+
+    public addEdge(dest: Node) {
+        if (!this.edges.has(dest.name)) {
+            this.edges.set(dest.name, dest);
+        }
+    }
+
+    public getAdjacency(): Map<string, Node> {
+        return this.edges;
+    }
+
+    public combineWith(rhs: NodeImpl): NodeGroup {
+        if (rhs instanceof NodeGroup) {
+            return rhs.combineWith(this);
+        }
+
+        const ng: NodeGroup = new NodeGroup();
+        ng.addNode(this);
+        ng.addNode(rhs);
+        return ng;
+    }
+}
+
+export class NodeGroup extends NodeImpl {
+    private readonly _nodes: Set<ScalarNode> = new Set<ScalarNode>();
+    private adjacencyCache: Map<string, ScalarNode>;
+
+    constructor() {
+        super('NodeGroup', undefined);
+    }
+
+    public get name(): string {
+        return Array.from(this.nodes).map(node => node.name).sort().join(', ');
+    }
+
+    get nodes(): Set<ScalarNode> {
+        return this._nodes;
+    }
+
+    public get details(): Map<string, object> {
+        const ret: Map<string, object> = new Map<string, object>();
+        this.nodes.forEach(element => {
+            Array.from(element.details.entries()).forEach(detail => {
+               ret.set(detail[0], detail[1]);
+            });
+        });
+        return ret;
+    }
+
+    public addEdge(dest: Node) {
+        throw new Error('Don\'t add edges to combined nodes');
+    }
+
+    public getAdjacency(): Map<string, Node> {
+        if (this.adjacencyCache) {
+            return this.adjacencyCache as Map<string, Node>;
+        }
+
+        this.adjacencyCache = new Map<string, ScalarNode>();
+        this.nodes.forEach(element => {
+            element.getAdjacency().forEach(n => {
+                    // if a node has a cycle to itself then preserve it.  if it's an
+                    // edge between two nodes in the nodegroup, skip it.
+                    if (element === n || !this.nodes.has(n as ScalarNode)) {
+                        this.adjacencyCache.set(n.name, n as ScalarNode);
+                    }
+                }
+            );
+        });
+        return this.adjacencyCache;
+    }
+    public combineWith(rhs: NodeImpl): NodeGroup {
+        if (rhs instanceof ScalarNode) {
+            this.addNode(rhs);
+            this.adjacencyCache = null;
+            return this;
+        }
+
+        assert.ok(rhs instanceof NodeGroup);
+        (rhs as NodeGroup).nodes.forEach(element => {
+                this.nodes.add(element);
+            }
+        );
+
+        return rhs as NodeGroup;
+    }
+
+    public addNode(node: NodeImpl): void {
+        assert.ok(node as ScalarNode);
+        this.nodes.add(node as ScalarNode);
+    }
+}

--- a/test/commands/andyinthecloud/dependencies/componentizer.test.ts
+++ b/test/commands/andyinthecloud/dependencies/componentizer.test.ts
@@ -1,0 +1,55 @@
+import * as Analyze from '../../../../src/commands/andyinthecloud/dependencies/componentizer';
+import * as Assert from 'assert';
+import { expect, test } from '@salesforce/command/dist/test';
+import {Node,Graph} from '../../../../src/lib/componentGraph';
+import {FindCycles} from '../../../../src/lib/DFSLib';
+
+const fs = require('fs');
+const path = require('path')
+
+
+function getAdjacency(graph: Graph, node: Node) : Map<string, Node> {
+    const edges: Map<string, Node> = new Map<string, Node>();
+    Array.from(graph.getEdges(node)).forEach((edge) => {
+        edges.set(edge.name, edge);
+    });
+    return edges;
+}
+describe ('Simple', function() {
+    it('Test simple graph', function() {
+        let obj : any = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../graph/data/simple.json'), 'utf8'));
+
+        console.log(obj.result.records);
+        let graph : Graph = Analyze.default.buildGraph(obj.result.records);
+        console.log(JSON.stringify(graph));
+        let a = graph.getNode("A");
+        let b = graph.getNode("B");
+        let c = graph.getNode("C");
+        Assert.ok(a, "A doesn't exist");
+        Assert.ok(b, "B doesn't exist");
+        Assert.ok(c, "C doesn't exist");
+
+        console.log(getAdjacency(graph, a));
+        console.log(getAdjacency(graph, a).get('B'));
+        Assert.ok(getAdjacency(graph, a).has("B"), "A not connected to B");
+        Assert.ok(getAdjacency(graph, a).has("C"), "A not connected to C");
+        Assert.ok(getAdjacency(graph, b).has("C"), "B not connected to C");
+        Assert.ok(getAdjacency(graph, c).size == 0, "C is not empty");
+    });
+
+});
+
+
+describe ('Very Simple', function() {
+    it('Test simple graph cycles', function() {
+        let obj : any = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../graph/data/verysimple.json'), 'utf8'));
+        let graph : Graph = Analyze.default.buildGraph(obj.result.records);
+        //console.log(JSON.stringify(graph));
+        let cycles = new FindCycles(graph);
+        cycles.run();
+        console.log(cycles[0]);
+        console.log(cycles); //Should be no cycles
+        expect(cycles.cycles).to.deep.equals(new Array<Node[]>());
+    });
+
+});

--- a/test/commands/andyinthecloud/dependencies/report.test.ts
+++ b/test/commands/andyinthecloud/dependencies/report.test.ts
@@ -84,14 +84,6 @@ describe('org', () => {
     // Mock an org that the command can use
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(async (...args) => {
-      // You can set a debugger here, and inspect request
-      // There are things on here you can use to determine
-      // what data to return, like the url path. So in another
-      // test, you may have several different ifs returning
-      // data for custom fields, custom objects, validation
-      // rules, etc.
-      // const request = args[0];
-
       // Just return empty everything for this 
         return { records: [] };
     })
@@ -116,14 +108,6 @@ describe('org test one object', () => {
     // Mock an org that the command can use
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(async (...args) => {
-      // You can set a debugger here, and inspect request
-      // There are things on here you can use to determine
-      // what data to return, like the url path. So in another
-      // test, you may have several different ifs returning
-      // data for custom fields, custom objects, validation
-      // rules, etc.
-      // const request = args[0];
-
         if (args[0].url.startsWith(urlGetRecords)) {
           //very first request, looking for records
           return {records: oneObjectRecords}
@@ -145,14 +129,6 @@ describe('org test two objects' , () => {
     // Mock an org that the command can use
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(async (...args) => {
-      // You can set a debugger here, and inspect request
-      // There are things on here you can use to determine
-      // what data to return, like the url path. So in another
-      // test, you may have several different ifs returning
-      // data for custom fields, custom objects, validation
-      // rules, etc.
-      // const request = args[0];
-
         if (args[0].url.startsWith(urlGetRecords)) {
           //very first request, looking for records
           return {records: twoObjectRecords}
@@ -174,14 +150,6 @@ describe('org test one custom field' , () => {
     // Mock an org that the command can use
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(async (...args) => {
-      // You can set a debugger here, and inspect request
-      // There are things on here you can use to determine
-      // what data to return, like the url path. So in another
-      // test, you may have several different ifs returning
-      // data for custom fields, custom objects, validation
-      // rules, etc.
-      // const request = args[0];
-
         if (args[0].url.startsWith(urlGetRecords)) {
           //very first request, looking for records
           return {records: oneCustomFieldRecords}
@@ -211,14 +179,6 @@ describe('org test one validation rule' , () => {
     // Mock an org that the command can use
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(async (...args) => {
-      // You can set a debugger here, and inspect request
-      // There are things on here you can use to determine
-      // what data to return, like the url path. So in another
-      // test, you may have several different ifs returning
-      // data for custom fields, custom objects, validation
-      // rules, etc.
-      // const request = args[0];
-
         if (args[0].url.startsWith(urlGetRecords)) {
           //very first request, looking for records
           return {records: oneValidationRuleRecords}
@@ -248,14 +208,6 @@ describe('org test two custom fields, 1 validation rule' , () => {
     // Mock an org that the command can use
     .withOrg({ username: 'test@org.com' }, true)
     .withConnectionRequest(async (...args) => {
-      // You can set a debugger here, and inspect request
-      // There are things on here you can use to determine
-      // what data to return, like the url path. So in another
-      // test, you may have several different ifs returning
-      // data for custom fields, custom objects, validation
-      // rules, etc.
-      // const request = args[0];
-
         if (args[0].url.startsWith(urlGetRecords)) {
           //very first request, looking for records
           return {records: TwoFields1VRRecords}

--- a/test/graph/data/verysimple.json
+++ b/test/graph/data/verysimple.json
@@ -1,0 +1,21 @@
+{  
+   "status":0,
+   "result":{  
+      "entityTypeName":"MetadataComponentDependency",
+      "records":[  
+         {  
+            "attributes":{  
+               "type":"MetadataComponentDependency"
+            },
+            "MetadataComponentId":"A",
+            "MetadataComponentNamespace":null,
+            "MetadataComponentName":"Node A",
+            "MetadataComponentType":"Node",
+            "RefMetadataComponentId":"B",
+            "RefMetadataComponentNamespace":null,
+            "RefMetadataComponentName":"Node B",
+            "RefMetadataComponentType":"Node"
+         }
+			]
+	 }
+}

--- a/test/graph/graph.test.ts
+++ b/test/graph/graph.test.ts
@@ -1,7 +1,8 @@
+import { expect, test } from '@salesforce/command/dist/test';
 import * as Analyze from '../../src/commands/andyinthecloud/dependencies/componentizer';
 import * as Assert from 'assert';
 
-import { expect } from 'chai';
+//import { expect } from 'chai';
 const fs = require('fs');
 const path = require('path')
 /*
@@ -106,6 +107,7 @@ describe ('Simple', function() {
         for (const node of graph.nodes) {
             console.log(JSON.stringify(node.name));
         };
+
         //console.log(JSON.stringify(graph.nodes));
         const a = graph.getNode('A');
         const b = graph.getNode('B');
@@ -127,4 +129,19 @@ describe ('Simple', function() {
         Assert.equal(getAdjacency(graph, ij).size, 0);
     });
 
+    describe('run async method cycles', () => {
+        test
+            // Mock an org that the command can use
+            .withOrg({ username: 'test@org.com' }, true)
+            .withConnectionRequest(async (...args) => {
+
+                let obj1 : any = JSON.parse(fs.readFileSync(path.join(__dirname, 'data/cycles.json'), 'utf8'));
+                return obj1.result;
+            })
+            .stdout({ print: true })
+            .command(['andyinthecloud:dependencies:componentizer', '-u', 'test@org.com'])
+            .it('runs org --targetusername test@org.com', ctx => {
+            
+            })
+    });
 });


### PR DESCRIPTION
…ters. These filters allow for the capability to choose which items in the org you want to see and list them by MetadataType and MetadataName. Also, you can use the -t flag to automatically request all the dependencies for the the files you wanted to include and exclude. Finally, you can use the -o flag and specify anoutput folder to store a package.xml file. This file can then be used in an mdapi retrieve to create a package (This is most useful to use with the -t flag to make sure no dependencies are missing). Finally, there were many changes to the code structure itself to allow it to be packaged nicer and allow for more reuse.