### PR TITLE
Made several changes. One, created new function (packages:report) tha…

### DIFF
--- a/messages/depends.json
+++ b/messages/depends.json
@@ -7,5 +7,6 @@
   "excludeListDescription": "list of fields to exclude when querying. Adding a colon allows you to specify the name of specific custom object to exclude e.g 'CustomField:Thumbnail, CustomObject'",
   "generatePackageDescription": "Whether or not you want to generate a package, the input is the output folder",
   "getIncludeDependencies": "For all objects in the include list, get all dependencies, including dependencies for dependencies",
+  "excludePackageDescription": "Does not include any of the objects listed in an attached package.xml into the generated package.xml",
   "example1": "$ sfdx andyinthelcloud:depends --metadatacomponentname CustomField.Thumbnail"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "@oclif/errors": "^1.0.9",
     "@salesforce/command": "0.1.5",
     "debug": "^3.1.0",
-    "file-system": "^2.2.2"
+    "file-exists": "^5.0.1",
+    "file-system": "^2.2.2",
+    "xml2js": "^0.4.19"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.2.20",

--- a/src/commands/andyinthecloud/packages/merge.ts
+++ b/src/commands/andyinthecloud/packages/merge.ts
@@ -1,0 +1,138 @@
+import fs = require('fs');
+import {flags, SfdxCommand} from '@salesforce/command';
+import {ClusterPackager} from '../../../lib/clusterPackager';
+
+
+export class Member {
+  constructor(public name: string, public type: string) { }
+
+  public equals(other: Member): boolean {
+    return (this.name == other.name && this.type == other.type);
+  }
+}
+
+export class PackageMerger {
+
+
+  static parseXML : any = require('xml2js');
+
+  public static parseIntoMap(fileName: string): Map<String,Array<Member>> {
+    let xmlOutput = fs.readFileSync(fileName);
+    let outputMap = new Map<String,Array<Member>>();
+    PackageMerger.parseXML.parseString(xmlOutput, (err: any, res: any) => {
+      for (var i = 0; i < res.Package.types.length; i++) {
+        let objects = new Array<Member>();
+        let arr = res.Package.types[i];
+        let type = arr.name[0];
+        for (var j = 0; j < arr.members.length; j++) {
+          let record = new Member(arr.members[j], type);
+          objects.push(record);
+        }
+        outputMap.set(type, objects);
+      }
+    });
+    return outputMap;
+  }
+
+  public static containsMember(name: String, type: String, map: Map<String,Array<Member>>): boolean {
+    if (map == null) {
+      return false;
+    }
+    let arr = map.get(type);
+    if (arr) {
+      for (var i = 0; i < arr.length; i++) {
+        if (arr[i].name == name && arr[i].type == type) {
+          return true;
+        }
+      }
+    }
+   return false;
+  }
+
+}
+
+
+export default class PackageMerging extends SfdxCommand {
+  static description = 'This tool allows you to merge several package.xmls together to create one base package.xml';
+
+  protected static flagsConfig= {
+    help: flags.help({char: 'h', description: 'get some help'}),
+    // flag with no value (-f, --force)
+  }
+
+  static strict = false
+  static args = [{
+    name: 'files',
+    required: true
+  }];
+
+  async run() {
+    const {args, flags} = this.parse(PackageMerging)
+
+    let fileArray = new Array<Map<String,Array<Member>>>();
+
+    for (var i = 0; i <this.argv.length; i++) {
+      let objArray = PackageMerger.parseIntoMap(this.argv[i]);
+      fileArray.push(objArray);
+    }
+    let basePackageArray = fileArray[0];
+    if (fileArray.length >= 2) {
+      basePackageArray = this.mergeArrays(fileArray);
+    }
+
+    // Write package.xml
+    let packageString = this.writePackageXml(basePackageArray);
+
+    console.log(packageString);
+  }
+
+  private mergeArrays(fileArray: Array<Map<String,Array<Member>>>): Map<String,Array<Member>> {
+    let base = fileArray[0];
+    for (var i = 1; i < fileArray.length; i++) {
+      base.forEach((pair: Array<Member>, type: String) => {
+        if (pair) {
+          for (var j = 0; j < pair.length; j++) {
+            if (!PackageMerger.containsMember(pair[j].name, pair[j].type, fileArray[i])) {
+              pair[j] = null;
+            }
+          }
+        }
+      });
+    }    
+    return base;
+  }
+
+  private writePackageXml(baseMap: Map<String, Array<Member>>): String {
+    let xmlString = ClusterPackager.writeHeader();
+    baseMap.forEach( (memberList: Array<Member>, type: String) => {
+      let typeString = this.writeType(type, memberList);
+      xmlString = xmlString.concat(typeString.valueOf());
+    });
+    xmlString = xmlString.concat(ClusterPackager.writeFooter());
+    return xmlString;
+  }
+
+  private writeType(type: String, members: Array<Member>): String {
+    let nullCount = 0;
+    let typeBody = '\t<types>\n';
+    for (const member of members) {
+      if (member != null) {
+        typeBody = typeBody.concat('\t\t<members>');
+        typeBody = typeBody.concat(member.name.valueOf());
+        typeBody = typeBody.concat('</members>');
+        typeBody = typeBody.concat('\n');
+      } else {
+        nullCount++;
+      }
+    }
+    typeBody = typeBody.concat('\t\t<name>');
+    typeBody = typeBody.concat(type.valueOf());
+    typeBody = typeBody.concat('</name>\n');
+    typeBody = typeBody.concat('\t</types>\n');
+    if (nullCount == members.length) {
+      return '';
+    }
+    return typeBody;
+  }
+   
+}

--- a/src/lib/componentGraph.ts
+++ b/src/lib/componentGraph.ts
@@ -1,5 +1,6 @@
 // TODO: Merge dependencyGraph and componentGraph
 import assert = require('assert');
+import { FieldDefinition } from './dependencyGraph';
 
 export class Graph {
     private _nodes: Map<string, Node> = new Map<string, Node>();
@@ -7,6 +8,37 @@ export class Graph {
 
     public get nodes(): IterableIterator<Node> {
         return this._nodes.values();
+    }
+
+    public getNodeFromName(name: string): Node {
+        let found: Node;
+        this._nodes.forEach(node => {
+            if ((node.details.get('name') as String).startsWith(name) && (node.details.get('type') as String) === "CustomObject") {
+                found = node; // Returning node here does not work and I don't know why 
+            }
+        });
+        return found;
+    }
+
+    public getNodeShortId(name: string): Node {
+        let found: Node;
+        this._nodes.forEach(node => {
+            if (node.name.startsWith(name)) {
+                found = node; // Returning node here does not work and I don't know why 
+            }
+        });
+        return found;
+    }
+
+    public addFields(fields: FieldDefinition[]) {
+        fields.forEach(fielddef => {
+            let n1 = this.getNodeShortId(fielddef.EntityDefinitionId);
+            const objName = fielddef.DataType.slice(fielddef.DataType.indexOf("(") + 1, fielddef.DataType.lastIndexOf(")"));
+            let n2: Node = this.getNodeFromName(objName);
+            if (n1 != null && n2 != null) {
+                this.addEdge(n1, n2);
+            }
+        })
     }
 
     public getEdges(node: Node): IterableIterator<Node> {
@@ -33,6 +65,7 @@ export class Graph {
     }
 
     public combineNodes(node1: Node, node2: Node): Node {
+        console.log(node1.name);
         assert.ok(this._nodes.has(node1.name), node1.name + ' doesn\'t exist');
         assert.ok(this._nodes.has(node2.name), node2.name + ' doesn\'t exist');
         if (node1 === node2) {

--- a/test/commands/andyinthecloud/packages/merge.test.ts
+++ b/test/commands/andyinthecloud/packages/merge.test.ts
@@ -1,0 +1,17 @@
+import {expect, test} from '@oclif/test'
+
+describe('andyinthecloud:packages:merge', () => {
+  test
+  .stdout()
+  .command(['andyinthecloud:packages:merge'])
+  .it('runs hello', ctx => {
+    expect(ctx.stdout).to.contain('hello world')
+  })
+
+  test
+  .stdout()
+  .command(['andyinthecloud:packages:merge', '--name', 'jeff'])
+  .it('runs hello --name jeff', ctx => {
+    expect(ctx.stdout).to.contain('hello jeff')
+  })
+})

--- a/test/lib/clusterPackager.test.ts
+++ b/test/lib/clusterPackager.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '@salesforce/command/dist/test';
+import { ClusterPackager } from '../../src/lib/clusterPackager';
+import {stub} from 'sinon';
+import fs = require('fs');
+import { NodeGroup, Node, ScalarNode } from '../../src/lib/componentGraph';
+
+
+let emptyXml = '<?xml version="1.0" encoding="UTF-8"?>\n<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n\t<version>43.0</version>\n</Package>';
+let oneNodeXml ='<?xml version="1.0" encoding="UTF-8"?>\n<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n\t<types>\n\t\t<members>G</members>\n\t\t<name>BasicNode</name>\n\t</types>\n\t<version>43.0</version>\n</Package>';
+let fiveNodeXml = '<?xml version="1.0" encoding="UTF-8"?>\n<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n\t<types>\n\t\t<members>G</members>\n\t\t<members>H</members>\n\t\t<members>J</members>\n\t\t<members>K</members>\n\t\t<members>L</members>\n\t\t<name>BasicNode</name>\n\t</types>\n\t<version>43.0</version>\n</Package>';
+let fourNodeXml = '<?xml version="1.0" encoding="UTF-8"?>\n<Package xmlns="http://soap.sforce.com/2006/04/metadata">\n\t<types>\n\t\t<members>G</members>\n\t\t<members>H</members>\n\t\t<name>BasicNode</name>\n\t</types>\n\t<types>\n\t\t<members>J</members>\n\t\t<members>K</members>\n\t\t<name>BasicNode2</name>\n\t</types>\n\t<version>43.0</version>\n</Package>';
+
+function createNode (id: string, name: String, type: String ): Node {
+  let details = new Map<string, object>();
+  details.set('name', name);
+  details.set('type', type);
+  let n = new ScalarNode(id, details);
+  return n;
+}
+
+describe('All file tests', () => {
+  let contents = '';
+  let folder = '';
+  let clusterPackager: ClusterPackager;
+
+  beforeEach(() => {
+    clusterPackager = new ClusterPackager('../test/lib')
+    stub (fs, "mkdirSync");
+    stub(fs, "writeFileSync").callsFake((dest, text) => {
+      contents = text;
+      folder = dest;
+    })
+  });
+
+  afterEach(() => {
+    fs.writeFileSync.restore();
+    fs.mkdirSync.restore();
+  });
+
+
+
+  describe('blank test, writes nothing', () => {
+    test
+    .it('Sends in no records and so should output just header and footer', () => {
+      let g = new NodeGroup();
+      clusterPackager.writeXML(g); 
+      expect(folder).to.equal('../test/lib/' + g.name+ '/package.xml');
+      expect(contents).to.equal(emptyXml);
+    })
+
+  });
+
+  describe('one Node', () => {
+    test
+    .it('Sends in one node', () => {
+      let nodeList = new Array<Node>();
+      let gNode = createNode('G', "G", 'BasicNode');
+      nodeList.push(gNode);
+      clusterPackager.writeXMLNodes(nodeList);
+      expect(folder).to.equal('../test/lib/package.xml');
+      expect(contents).to.equal(oneNodeXml);
+    })
+
+  });
+
+  describe('5 nodes, 1 type', () => {
+    test
+    .it('Sends in one node', () => {
+      let nodeList = new Array<Node>();
+      let gNode = createNode('g', "G", 'BasicNode');
+      let hNode = createNode('h', "H", 'BasicNode');
+      let iNode = createNode('j', "J", 'BasicNode');
+      let jNode = createNode('k', "K", 'BasicNode');
+      let kNode = createNode('l', "L", 'BasicNode');
+      nodeList.push(gNode);
+      nodeList.push(hNode);
+      nodeList.push(iNode);
+      nodeList.push(jNode);
+      nodeList.push(kNode);
+      clusterPackager.writeXMLNodes(nodeList);
+      expect(folder).to.equal('../test/lib/package.xml');
+      expect(contents).to.equal(fiveNodeXml);
+    })
+
+  });
+
+  describe('4 nodes, 2 types', () => {
+    test
+    .it('Sends in one node', () => {
+      let nodeList = new Array<Node>();
+      let gNode = createNode('g', "G", 'BasicNode');
+      let hNode = createNode('h', "H", 'BasicNode');
+      let jNode = createNode('j', "J", 'BasicNode2');
+      let kNode = createNode('k', "K", 'BasicNode2');
+      nodeList.push(gNode);
+      nodeList.push(hNode);
+      nodeList.push(jNode);
+      nodeList.push(kNode);
+      clusterPackager.writeXMLNodes(nodeList);
+      expect(folder).to.equal('../test/lib/package.xml');
+      expect(contents).to.equal(fourNodeXml);
+    })
+
+  });
+
+  describe('Big Node Group', () => {
+    test
+    .it('Sends in one node', () => {
+      let gNode = createNode('g', "G", 'BasicNode');
+      let hNode = createNode('h', "H", 'BasicNode');
+      let jNode = createNode('j', "J", 'BasicNode2');
+      let kNode = createNode('k', "K", 'BasicNode2');
+      let nodeGroup = (gNode as ScalarNode).combineWith(hNode as ScalarNode);
+      nodeGroup.combineWith(jNode as ScalarNode);
+      nodeGroup.combineWith(kNode as ScalarNode);
+      clusterPackager.writeXML(nodeGroup);
+      expect(folder).to.equal('../test/lib/g, h, j, k/package.xml');
+      expect(contents).to.equal(fourNodeXml);
+    })
+
+  });
+
+
+
+});

--- a/test/lib/dependencyGraphy.test.ts
+++ b/test/lib/dependencyGraphy.test.ts
@@ -66,12 +66,14 @@ describe('no relationship single node dependency graph', () => {
   // Can define here if you want to use them in multiple tests
   // TODO you probably want to make this more meaningful
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Don't use a connection, just mock methods
     graph = new DependencyGraph(null);
 
     // Don't try to call out to tooling
     stub(graph, 'retrieveRecords').returns(Promise.resolve([]));
+
+    await graph.init();
   });
 
   // TODO you could have one of these for each public method in dependency graph.
@@ -79,7 +81,7 @@ describe('no relationship single node dependency graph', () => {
   // they should be covered from the public method tests.
   describe('init', () => {
     it('populates nodes and edges for one record', async () => {
-      await graph.init(oneObjectRecords);
+      await graph.buildGraph(oneObjectRecords);
 
       expect(graph.nodes.length).to.equal(1);
       expect(graph.edges.length).to.equal(1);
@@ -88,7 +90,7 @@ describe('no relationship single node dependency graph', () => {
 
   describe('to dot format', () => {
     it('Check dot format', async () => {
-      await graph.init(oneObjectRecords);
+      await graph.buildGraph(oneObjectRecords);
 
       expect(graph.toDotFormat()).to.contain(dotOutput1);
     });
@@ -97,7 +99,8 @@ describe('no relationship single node dependency graph', () => {
 
   describe('getParentRecords', () => {
     it('gets parent records of no parents', async () => {
-      await graph.init(oneObjectRecords);
+      await graph.init();
+      graph.buildGraph(oneObjectRecords);
       
       expect(graph.getParentRecords()).to.deep.equal(new Map());
       expect(graph.nodes.length).to.equal(1);
@@ -107,7 +110,7 @@ describe('no relationship single node dependency graph', () => {
 
   describe('toJson', () => {
     it('check Json of 1 node 1 edge tree', async () => {
-      await graph.init(oneObjectRecords);
+      graph.buildGraph(oneObjectRecords);
       let key = '1';
       let value = {parent: '', name: 'Object1', type: 'Object'};
       let edge1 = {from: '1', to: '1'};
@@ -123,7 +126,7 @@ describe('no relationship single node dependency graph', () => {
 
 });
 
-describe('one relationship, two custom fields, one vrule dependency graph', () => {
+describe('one relationship, two custom fields, one vrule dependency graph', async () => {
   let graph: DependencyGraph;
  
   beforeEach(() => {
@@ -143,7 +146,8 @@ describe('one relationship, two custom fields, one vrule dependency graph', () =
   // they should be covered from the public method tests.
   describe('init', () => {
     it('populates nodes and edges for one record', async () => {
-      await graph.init(TwoFields1VRRecords);
+      await graph.init();
+      graph.buildGraph(TwoFields1VRRecords);
 
       expect(graph.nodes.length).to.equal(3);
       expect(graph.edges.length).to.equal(2);
@@ -152,7 +156,8 @@ describe('one relationship, two custom fields, one vrule dependency graph', () =
 
   describe('getParentRecords', () => {
     it('gets parent records of no parents', async () => {
-      await graph.init(TwoFields1VRRecords);
+      await graph.init();
+      graph.buildGraph(TwoFields1VRRecords);
       let expectedMap = new Map();
       expectedMap.set('1', 'ObjectA');
       expectedMap.set('2', 'ObjectA');
@@ -163,7 +168,8 @@ describe('one relationship, two custom fields, one vrule dependency graph', () =
 
   describe('to dot format', () => {
     it('Check dot format', async () => {
-      await graph.init(TwoFields1VRRecords);
+      await graph.init();
+      graph.buildGraph(TwoFields1VRRecords);
 
       expect(graph.toDotFormat()).to.contain(dotOutput2);
     });


### PR DESCRIPTION
…t allows you to put several package.xmls together and will output one base package.xml. Second, there is a new flag added to dependencies:report that allows you to attach a package.xml. Then, when the command generates a package.xml, it will leave out any objects that are included in the package.xml given in the flag. Note that it does not change the dot output. Finally tests were created to test the package.xml export and the include and exclude list.