### PR TITLE
solve issue #21 (https://github.com/afawcett/dependencies-cli/issues/…

### DIFF
--- a/src/commands/andyinthecloud/dependencies/report.ts
+++ b/src/commands/andyinthecloud/dependencies/report.ts
@@ -1,9 +1,7 @@
 import {core, flags, SfdxCommand } from '@salesforce/command';
-import {Connection} from '@salesforce/core';
 import process = require('child_process');
 import {ClusterPackager} from '../../../lib/clusterPackager';
 import {DependencyGraph} from '../../../lib/dependencyGraph';
-import {FindAllDependencies} from '../../../lib/DFSLib';
 import {FileWriter} from '../../../lib/fileWriter';
 import {MetadataComponentDependency, Node} from '../../../lib/NodeDefs';
 import {Member, PackageMerger} from '../../../lib/PackageMerger';

--- a/src/commands/andyinthecloud/manifests/merge.ts
+++ b/src/commands/andyinthecloud/manifests/merge.ts
@@ -16,8 +16,6 @@ export default class PackageMerging extends SfdxCommand {
     // flag with no value (-f, --force)
   };
 
-  private homedir = require('os').homedir();
-
   public async run(): Promise<string> {
 
     const fileArray = new Array<Map<string, Member[]>>();


### PR DESCRIPTION
solve issue #21 (https://github.com/afawcett/dependencies-cli/issues/21) by

- reducing large SOQL queries to smaller sub-queries
- join the results of sub-queries
- perform recursive exeuction until all queries have been executed

This fix has been tested with the TZ org, resulting in a graph of 15K records.

	modified:   src/commands/andyinthecloud/dependencies/report.ts
	modified:   src/commands/andyinthecloud/manifests/merge.ts
	modified:   src/lib/dependencyGraph.ts