### PR TITLE
Further reduce query size to 10 params

### DIFF
--- a/src/lib/dependencyGraph.ts
+++ b/src/lib/dependencyGraph.ts
@@ -226,7 +226,7 @@ export class DependencyGraph extends AbstractGraph {
 
     var query = `SELECT EntityDefinitionId,DataType,DurableId FROM FieldDefinition c WHERE c.EntityDefinitionId In `;
 
-    const maxNumberOfIds = 25;
+    const maxNumberOfIds = 10;
     var splitIds = this.splitIds(ids, query, maxNumberOfIds);
 
     query = query.concat(this.arrayToInIdString(splitIds.left));


### PR DESCRIPTION
Different org level settings seem to support different query size limits. 

Issue https://github.com/afawcett/dependencies-cli/issues/21 was finally resolved for the customer trying a value of 10.