### PR TITLE
Fix for issue #24 - URI too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependencies-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Andrew Fawcett, Justin Kalloor",
   "bugs": "https://github.com/afawcett/dependencies-cli/issues",
   "dependencies": {


### PR DESCRIPTION
See https://github.com/afawcett/dependencies-cli/issues/24

- apply the recursive execution logic to all queries with parameters
- limit the number of parameters to 10 per execution

Cut new version 1.0.1

	modified:   package.json
	modified:   src/lib/dependencyGraph.ts